### PR TITLE
Use HTTPS for Twitter Maven repo

### DIFF
--- a/bin/dbuild.properties
+++ b/bin/dbuild.properties
@@ -24,7 +24,7 @@
   scala-fresh-2.10.x: http://repo.typesafe.com/typesafe/scala-fresh-2.10.x/
   conjars: http://conjars.org/repo
   clojars: http://clojars.org/repo
-  twitter_mvn: http://maven.twttr.com
+  twitter_mvn: https://maven.twttr.com
 
 [boot]
  directory: ${dbuild.boot.directory-${dbuild.global.base-${user.home}/.dbuild}/boot/}


### PR DESCRIPTION
See [this blog post](https://finagle.github.io/blog/2015/07/16/ssl-now-supported-for-maven-twttr-com/) for details.
